### PR TITLE
ensure integration rule propogated

### DIFF
--- a/src/ilqr/rollout.jl
+++ b/src/ilqr/rollout.jl
@@ -29,8 +29,8 @@ function rollout!(solver::iLQRSolver{T,Q,n}, α) where {T,Q,n}
 end
 
 "Simulate the forward the dynamics open-loop"
-function rollout!(solver::iLQRSolver)
-    rollout!(solver.model, solver.Z, solver.x0)
+function rollout!(solver::iLQRSolver{T,Q,n}) where {T,Q,n}
+    rollout!(Q, solver.model, solver.Z, solver.x0)
     for k in eachindex(solver.Z)
         solver.Z̄[k].t = solver.Z[k].t
     end


### PR DESCRIPTION
This is a simple fix for https://github.com/RoboticExplorationLab/TrajectoryOptimization.jl/issues/32 that ensures that the quadrature rule is propagated to all functions. Previously DEFAULT_Q would be used in certain dynamics calls.