### PR TITLE
Nonstatic Backward Pass

### DIFF
--- a/src/ilqr/backwardpass.jl
+++ b/src/ilqr/backwardpass.jl
@@ -144,7 +144,7 @@ function _bp_reg!(Quu_reg::SizedMatrix{m,m}, Qux_reg, Q, fdx, fdu, ρ, ver=:cont
     if ver == :state
         Quu_reg .= Q.R #+ solver.ρ[1]*fdu'fdu
 		mul!(Quu_reg, Transpose(fdu), fdu, ρ, 1.0)
-        Qux_reg .= Q.J #+ solver.ρ[1]*fdu'fdx
+        Qux_reg .= Q.H #+ solver.ρ[1]*fdu'fdx
 		mul!(Qux_reg, fdu', fdx, ρ, 1.0)
     elseif ver == :control
         Quu_reg .= Q.R #+ solver.ρ[1]*I

--- a/src/solver_opts.jl
+++ b/src/solver_opts.jl
@@ -156,7 +156,7 @@ end
 
 function reset!(stats::SolverStats, N::Int=0)
     stats.is_reset && return nothing
-    stats.iterations = 0
+    stats.iterations = 1
     stats.iterations_outer = 0
     stats.iterations_pn = 0
     function reset!(v::AbstractVector{T}, N::Int) where T 

--- a/src/solver_opts.jl
+++ b/src/solver_opts.jl
@@ -156,7 +156,7 @@ end
 
 function reset!(stats::SolverStats, N::Int=0)
     stats.is_reset && return nothing
-    stats.iterations = 1
+    stats.iterations = 0
     stats.iterations_outer = 0
     stats.iterations_pn = 0
     function reset!(v::AbstractVector{T}, N::Int) where T 

--- a/test/benchmark_problems.jl
+++ b/test/benchmark_problems.jl
@@ -5,98 +5,105 @@ if !isdefined(Main,:TEST_TIME)
     TEST_TIME = true 
 end
 
-# Double Integrator
-solver = ALTROSolver(Problems.DoubleIntegrator()...)
-b = benchmark_solve!(solver)
-TEST_TIME && @test minimum(b).time / 1e6 < 1 
-@test max_violation(solver) < 1e-6
-@test iterations(solver) == 8 # 8
-@test solver.stats.gradient[end] < 1e-9
-@test status(solver) == Altro.SOLVE_SUCCEEDED 
+default_option = []
+no_static_bp = [Expr(:kw, :static_bp, false)]
 
-# Pendulum
-solver = ALTROSolver(Problems.Pendulum()...)
-b = benchmark_solve!(solver)
-TEST_TIME && @test minimum(b).time / 1e6 < 2
-@test max_violation(solver) < 1e-6
-@test iterations(solver) == 19 # 19
-@test solver.stats.gradient[end] < 1e-3
-@test status(solver) == Altro.SOLVE_SUCCEEDED 
+options_set = [default_option, no_static_bp]
 
-# Cartpole
-solver = ALTROSolver(Problems.Cartpole()...)
-b = benchmark_solve!(solver)
-TEST_TIME && @test minimum(b).time / 1e6 <  10 
-@test max_violation(solver) < 1e-6
-@test iterations(solver) == 40 # 40
-@test solver.stats.gradient[end] < 1e-2
-@test status(solver) == Altro.SOLVE_SUCCEEDED 
+for added_options ∈ options_set
+    # Double Integrator
+    solver = @eval ALTROSolver(Problems.DoubleIntegrator()..., $(added_options...))
+    b = benchmark_solve!(solver)
+    TEST_TIME && @test minimum(b).time / 1e6 < 1 
+    @test max_violation(solver) < 1e-6
+    @test iterations(solver) == 8 # 8
+    @test solver.stats.gradient[end] < 1e-9
+    @test status(solver) == Altro.SOLVE_SUCCEEDED 
 
-# Acrobot
-solver = ALTROSolver(Problems.Acrobot()...)
-b = benchmark_solve!(solver)
-TEST_TIME && @test minimum(b).time / 1e6 < 10
-@test max_violation(solver) < 1e-6
-@test iterations(solver) == 50 # 50
-@test solver.stats.gradient[end] < 1e-2
-@test status(solver) == Altro.SOLVE_SUCCEEDED 
+    # Pendulum
+    solver = @eval ALTROSolver(Problems.Pendulum()..., $(added_options...))
+    b = benchmark_solve!(solver)
+    TEST_TIME && @test minimum(b).time / 1e6 < 2
+    @test max_violation(solver) < 1e-6
+    @test iterations(solver) == 19 # 19
+    @test solver.stats.gradient[end] < 1e-3
+    @test status(solver) == Altro.SOLVE_SUCCEEDED 
 
-# Parallel Park
-solver = ALTROSolver(Problems.DubinsCar(:parallel_park)...)
-b =  benchmark_solve!(solver)
-TEST_TIME && @test minimum(b).time /1e6 < 7 
-@test max_violation(solver) < 1e-6
-@test iterations(solver) == 13 # 13
-@test solver.stats.gradient[end] < 1e-3
-@test status(solver) == Altro.SOLVE_SUCCEEDED 
+    # Cartpole
+    solver = @eval ALTROSolver(Problems.Cartpole()..., $(added_options...))
+    b = benchmark_solve!(solver)
+    TEST_TIME && @test minimum(b).time / 1e6 <  10 
+    @test max_violation(solver) < 1e-6
+    @test iterations(solver) == 40 # 40
+    @test solver.stats.gradient[end] < 1e-2
+    @test status(solver) == Altro.SOLVE_SUCCEEDED
 
-# Three Obstacles
-solver = ALTROSolver(Problems.DubinsCar(:three_obstacles)...)
-b = benchmark_solve!(solver)
-TEST_TIME && @test minimum(b).time /1e6 < 6 
-@test max_violation(solver) < 1e-6
-@test iterations(solver) == 20 # 20
-@test solver.stats.gradient[end] < 1e-2
-@test status(solver) == Altro.SOLVE_SUCCEEDED 
+    # Acrobot
+    solver = @eval ALTROSolver(Problems.Acrobot()..., $(added_options...))
+    b = benchmark_solve!(solver)
+    TEST_TIME && @test minimum(b).time / 1e6 < 10
+    @test max_violation(solver) < 1e-6
+    @test iterations(solver) == 50 # 50
+    @test solver.stats.gradient[end] < 1e-2
+    @test status(solver) == Altro.SOLVE_SUCCEEDED 
 
-solver = ALTROSolver(Problems.DubinsCar(:three_obstacles)..., projected_newton=false)
-@test solver.opts.projected_newton == false 
-@test solver.stats.gradient[end] < 1e-1
-if !Sys.iswindows()   # not sure why this fails on Windows?
-    @test benchmark_solve!(solver).allocs == 0
+    # Parallel Park
+    solver = @eval ALTROSolver(Problems.DubinsCar(:parallel_park)..., $(added_options...))
+    b =  benchmark_solve!(solver)
+    TEST_TIME && @test minimum(b).time /1e6 < 7 
+    @test max_violation(solver) < 1e-6
+    @test iterations(solver) == 13 # 13
+    @test solver.stats.gradient[end] < 1e-3
+    @test status(solver) == Altro.SOLVE_SUCCEEDED 
+
+    # Three Obstacles
+    solver = @eval ALTROSolver(Problems.DubinsCar(:three_obstacles)..., $(added_options...))
+    b = benchmark_solve!(solver)
+    TEST_TIME && @test minimum(b).time /1e6 < 6 
+    @test max_violation(solver) < 1e-6
+    @test iterations(solver) == 20 # 20
+    @test solver.stats.gradient[end] < 1e-2
+    @test status(solver) == Altro.SOLVE_SUCCEEDED 
+
+    solver = @eval ALTROSolver(Problems.DubinsCar(:three_obstacles)..., projected_newton=false, $(added_options...))
+    @test solver.opts.projected_newton == false 
+    @test solver.stats.gradient[end] < 1e-1
+    if !Sys.iswindows()   # not sure why this fails on Windows?
+        @test benchmark_solve!(solver).allocs == 0
+        @test status(solver) == Altro.SOLVE_SUCCEEDED 
+    end
+
+    # Escape
+    solver = @eval ALTROSolver(Problems.DubinsCar(:escape)..., infeasible=true, R_inf=0.1, $(added_options...))
+    b = benchmark_solve!(solver)
+    TEST_TIME && @test minimum(b).time / 1e6 < 20
+    @test max_violation(solver) < 1e-6
+    @test iterations(solver) == 13 # 13
+    @test solver.stats.gradient[end] < 1e-3
+    @test status(solver) == Altro.SOLVE_SUCCEEDED 
+
+    # Zig-zag
+    solver = @eval ALTROSolver(Problems.Quadrotor(:zigzag)..., $(added_options...))
+    b = benchmark_solve!(solver)
+    TEST_TIME && @test minimum(b).time / 1e6 < 60
+    @test max_violation(solver) < 1e-6
+    @test iterations(solver) == 15 # 16
+    @test solver.stats.gradient[end] < 2e-2
+    @test status(solver) == Altro.SOLVE_SUCCEEDED 
+
+    solver = @eval ALTROSolver(Problems.Quadrotor(:zigzag)..., projected_newton=false, $(added_options...))
+    @test solver.stats.gradient[end] < 0.3
+    if !Sys.iswindows()   # not sure why this fails on Windows?
+        @test benchmark_solve!(solver).allocs == 0
+        @test status(solver) == Altro.SOLVE_SUCCEEDED 
+    end
+
+    # Barrell Roll
+    solver = @eval ALTROSolver(Problems.YakProblems()..., $(added_options...))
+    b = benchmark_solve!(solver)
+    TEST_TIME && @test minimum(b).time / 1e6 < 100 
+    @test max_violation(solver) < 1e-6
+    @test iterations(solver) == 18 # 18
+    @test solver.stats.gradient[end] < 1e-3
     @test status(solver) == Altro.SOLVE_SUCCEEDED 
 end
-
-# Escape
-solver = ALTROSolver(Problems.DubinsCar(:escape)..., infeasible=true, R_inf=0.1)
-b = benchmark_solve!(solver)
-TEST_TIME && @test minimum(b).time / 1e6 < 20
-@test max_violation(solver) < 1e-6
-@test iterations(solver) == 13 # 13
-@test solver.stats.gradient[end] < 1e-3
-@test status(solver) == Altro.SOLVE_SUCCEEDED 
-
-# Zig-zag
-solver = ALTROSolver(Problems.Quadrotor(:zigzag)...)
-b = benchmark_solve!(solver)
-TEST_TIME && @test minimum(b).time / 1e6 < 60
-@test max_violation(solver) < 1e-6
-@test iterations(solver) == 15 # 16
-@test solver.stats.gradient[end] < 2e-2
-@test status(solver) == Altro.SOLVE_SUCCEEDED 
-
-solver = ALTROSolver(Problems.Quadrotor(:zigzag)..., projected_newton=false)
-@test solver.stats.gradient[end] < 0.3
-if !Sys.iswindows()   # not sure why this fails on Windows?
-    @test benchmark_solve!(solver).allocs == 0
-    @test status(solver) == Altro.SOLVE_SUCCEEDED 
-end
-
-# Barrell Roll
-solver = ALTROSolver(Problems.YakProblems()...)
-b = benchmark_solve!(solver)
-TEST_TIME && @test minimum(b).time / 1e6 < 100 
-@test max_violation(solver) < 1e-6
-@test iterations(solver) == 18 # 18
-@test solver.stats.gradient[end] < 1e-3
-@test status(solver) == Altro.SOLVE_SUCCEEDED 

--- a/test/solver_opts.jl
+++ b/test/solver_opts.jl
@@ -19,7 +19,7 @@ Altro.set_options!(solver, verbose=0)
 
 # Test ALTRO solver options
 solver = ALTROSolver(prob, cost_tolerance=1e-1, square_root=true, 
-    iterations=210, iterations_outer=60, ρ_chol=1e-1, constraint_tolerance=1e-2)
+    iterations=210, iterations_outer=60, ρ_chol=1e-1, constraint_tolerance=1e-2, static_bp=false)
 @test solver.opts.cost_tolerance == 1e-1
 @test solver.solver_al.opts.cost_tolerance == 1e-1
 @test solver.solver_al.solver_uncon.opts.cost_tolerance == 1e-1
@@ -30,3 +30,4 @@ solver = ALTROSolver(prob, cost_tolerance=1e-1, square_root=true,
 @test solver.solver_pn.opts.constraint_tolerance == 1e-2
 @test solver.solver_al.opts.constraint_tolerance == 1e-2
 @test solver.opts.constraint_tolerance == 1e-2
+@test solver.solver_al.solver_uncon.opts.static_bp == false


### PR DESCRIPTION
This fixes improper variable names for the case when static_bp = false. 

It also makes the default iteration count in solver.stats 1 instead of 0 to prevent indexing error (this makes the tests fail because the expect one iteration less). 