### PR TITLE
Switch to using a general factorization method

### DIFF
--- a/src/direct/pn_methods.jl
+++ b/src/direct/pn_methods.jl
@@ -95,7 +95,7 @@ function _projection_solve!(solver::ProjectedNewtonSolver)
     end
 
     S = Symmetric(D*HinvD)
-    Sreg = cholesky(S + ρ_chol*I) #TODO is this fast or slow? try above
+    Sreg = factorize(S + ρ_chol*I) #TODO is this fast or slow? try above
     viol_prev = viol0
     count = 0
     while count < max_refinements


### PR DESCRIPTION
`_projection_solve!` uses a Cholesky factorization to help evaluate constraint violations (`pn_methods.jl:98`). However, Cholesky factorization only works on matrices which are positive definite. I don't think the matrix in question is necessarily positive definite (for instance, in the case of goal constraints. I've edited the code to use `LinearAlgebra.factorize` instead, which will still perform Cholesky factorization when possible for performance, but will use alternate factorizations when necessary. I'm not certain this is a mathematically correct approach.