### PR TITLE
Upload codecov

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,22 +26,6 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/julia-runtest@latest
-
-# Enable the below for Documenter build
-#  docs:
-#    name: Documentation
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v1
-#      - uses: julia-actions/setup-julia@latest
-#        with:
-#          version: '1.3'
-#      - run: julia --project=docs -e '
-#          using Pkg;
-#          Pkg.develop(PackageSpec(; path=pwd()));
-#          Pkg.instantiate();'
-#      - run: julia --project=docs docs/make.jl
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#          # Needed due to https://github.com/JuliaDocs/Documenter.jl/issues/1177
-#          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+      - uses: julia-actions/julia-uploadcodecov@latest
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Removes old `v0.4` solvers based on StaticArrays and generally cleans up the repo.