### PR TITLE
Fix Function Signature

### DIFF
--- a/src/altro/altro_solver.jl
+++ b/src/altro/altro_solver.jl
@@ -38,6 +38,7 @@ end
 function ALTROSolver(prob::Problem{T}, opts::SolverOptions=SolverOptions();
         infeasible::Bool=false,
         R_inf::Real=1.0,
+        use_static=usestaticdefault(get_model(prob)),
         kwarg_opts...
     ) where {Q,T}
     if infeasible
@@ -52,7 +53,7 @@ function ALTROSolver(prob::Problem{T}, opts::SolverOptions=SolverOptions();
     end
     set_options!(opts; kwarg_opts...)
     stats = SolverStats{T}(parent=solvername(ALTROSolver))
-    solver_al = ALSolver(prob, opts, stats)
+    solver_al = ALSolver(prob, opts, stats, use_static=use_static)
     solver_pn = ProjectedNewtonSolver2(prob, opts, stats)
     S = typeof(solver_al.ilqr)
     solver = ALTROSolver{T,S,typeof(solver_pn)}(opts, stats, solver_al, solver_pn)

--- a/src/augmented_lagrangian/al_solver.jl
+++ b/src/augmented_lagrangian/al_solver.jl
@@ -31,7 +31,7 @@ function ALSolver(
         prob::Problem{T}, 
         opts::SolverOptions=SolverOptions(), 
         stats::SolverStats=SolverStats(parent=solvername(ALSolver));
-        use_static=Val(false), 
+        use_static=usestaticdefault(get_model(prob)),
         kwarg_opts...
     ) where {T}
     set_options!(opts; kwarg_opts...)

--- a/src/ilqr/ilqr_solver.jl
+++ b/src/ilqr/ilqr_solver.jl
@@ -47,7 +47,7 @@ function iLQRSolver(
         prob::Problem{T}, 
         opts::SolverOptions=SolverOptions{T}(), 
         stats::SolverStats=SolverStats{T}(parent=solvername(iLQRSolver));
-        use_static::Val{USE_STATIC}=Val(false), 
+        use_static::Val{USE_STATIC}=usestaticdefault(get_model(prob)),
         kwarg_opts...
     ) where {T, USE_STATIC}
     set_options!(opts; kwarg_opts...)
@@ -138,6 +138,7 @@ RD.vectype(::iLQRSolver{<:Any,<:Any,<:Any,<:Any,<:Any,<:Any,V}) where V = V
 usestatic(obj) = RD.vectype(obj) <: SVector
 dynamics_signature(obj) = usestatic(obj) ? RD.StaticReturn() : RD.InPlace()
 function_signature(obj) = usestatic(obj) ? RD.StaticReturn() : RD.InPlace()
+usestaticdefault(model::RD.AbstractFunction) = Val(RD.default_signature(model) == RD.StaticReturn())
 
 log_level(::iLQRSolver) = InnerLoop
 

--- a/test/benchmark_problems.jl
+++ b/test/benchmark_problems.jl
@@ -15,7 +15,6 @@ ci = haskey(ENV, "CI")
 ## Double Integrator
 v && println("Double Integrator")
 solver = ALTROSolver(Problems.DoubleIntegrator()...)
-solve!(solver)
 b = benchmark_solve!(solver)
 TEST_TIME && @test minimum(b).time / 1e6 < 1 
 @test max_violation(solver) < 1e-6


### PR DESCRIPTION
Makes it easier to set the function signature that's used throughout the solver(s). Use the `use_static` keyword in any of the solver constructors. It will also be automatically deduced using the `default_signature` from RobotDynamics.