### PR TITLE
Simplify `getindex` and remove usage of `getkey`

### DIFF
--- a/src/direct/sparseblocks.jl
+++ b/src/direct/sparseblocks.jl
@@ -163,11 +163,8 @@ struct SparseBlockIndex
 end
 
 function Base.getindex(blocks::SparseBlocks, i1::UnitRange, i2::UnitRange)
-    block0 = BlockIndices(i1, i2, false)
-    block = getkey(blocks.inds, block0, nothing)
-    if isnothing(block)
-        throw(KeyError((i1, i2)))
-    end
+    block = BlockIndices(i1, i2, false)
+    haskey(blocks.inds, block) || throw(KeyError((i1, i2)))
     SparseBlockIndex(block, blocks.inds[block])
 end
 


### PR DESCRIPTION
The usage of `getkey` here is a roundabout way of writing `haskey`. This is simpler and avoids the use of `getkey`, an obscure function that is rarely useful and less likely to be as well maintained or efficiently implemented as `haskey`.

